### PR TITLE
Add some exercises to write tests

### DIFF
--- a/2-mandatory/5-writing-tests.js
+++ b/2-mandatory/5-writing-tests.js
@@ -43,10 +43,9 @@ test("a score of 83 is grade A", () => {
   write a matching test
 */
 
-/*
-  Write a test that checks a score of 71 is grade B
-*/
-
+test.skip("a score of 71 is grade B", () => {
+  /* Remove the .skip above, then write the test body. */
+});
 /*
   Write a test that checks a score of 68 is grade C
 */

--- a/2-mandatory/5-writing-tests.js
+++ b/2-mandatory/5-writing-tests.js
@@ -1,0 +1,76 @@
+/*
+  For this exercise, the function has been written for you and you need to write
+  the tests.
+
+  This function takes a marking coursework score and converts it into a string
+  representing a grade (from A to E). It then returns the grade.
+*/
+
+function convertScoreToGrade(score) {
+  let grade = null;
+
+  if (score >= 80) {
+    grade = "A";
+  } else if (score >= 70) {
+    grade = "B";
+  } else if (score >= 60) {
+    grade = "C";
+  } else if (score >= 50) {
+    grade = "D";
+  } else {
+    grade = "E";
+  }
+
+  return grade;
+}
+
+/* ======= TESTS - FOR THIS EXERCISE YOU SHOULD MODIFY THEM! =====
+- To run the tests for this exercise, run `npm test -- --testPathPattern 5-writing-tests.js`
+- To run all exercises/tests in the mandatory folder, run `npm test`
+- (Reminder: You must have run `npm install` one time before this will work!)
+*/
+
+/*
+  The first test has been written for you. You need to fix the test so that it
+  passes.
+*/
+test("a score of 83 is grade A", () => {
+  expect(convertScoreToGrade(83), "Z");
+});
+
+/*
+  The rest of the tests have comments describing what to test and you need to
+  write a matching test
+*/
+
+/*
+  Write a test that checks a score of 71 is grade B
+*/
+
+/*
+  Write a test that checks a score of 68 is grade C
+*/
+
+/*
+  Write a test that checks a score of 55 is grade D
+*/
+
+/*
+  Write a test that checks a score of 68 is grade C
+*/
+
+/*
+  Write a test that checks a score of 55 is grade D
+*/
+
+/*
+  Write a test that checks a score of 49 is grade E
+*/
+
+/*
+  Write a test that checks a score of 30 is grade E
+*/
+
+/*
+  Write a test that checks a score of 70 is grade B
+*/

--- a/2-mandatory/6-writing-tests-advanced.js
+++ b/2-mandatory/6-writing-tests-advanced.js
@@ -1,0 +1,91 @@
+/*
+  For this exercise, the function has been written for you and you need to write
+  the tests.
+
+  This function takes a trainee parameter that is an object. The object
+  contains: name (which represents the trainee's name) and score (which
+  represents the mark given to the trainee's coursework).
+
+  It uses these to format a string that tells the user how much coursework the
+  trainee has completed.
+*/
+
+function convertScoreToGrade() {
+  let grade = null;
+
+  if (score >= 80) {
+    grade = "A";
+  } else if (score >= 70) {
+    grade = "B";
+  } else if (score >= 60) {
+    grade = "C";
+  } else if (score >= 50) {
+    grade = "D";
+  } else {
+    grade = "E";
+  }
+
+  return grade;
+}
+
+function formatCourseworkResult(trainee) {
+  if (!trainee.name) {
+    return "Error: No trainee name!";
+  }
+  let traineeName = trainee.name;
+
+  if (typeof trainee.score != "number") {
+    return "Error: Coursework percent is not a number!";
+  }
+  let traineeGrade = convertScoreToGrade(trainee.score);
+
+  return `${traineeName}'s coursework was marked as grade ${traineeGrade}.`;
+}
+
+/* ======= TESTS - FOR THIS EXERCISE YOU SHOULD MODIFY THEM! =====
+- To run the tests for this exercise, run `npm test -- --testPathPattern 6-writing-tests-advanced.js`
+- To run all exercises/tests in the mandatory folder, run `npm test`
+- (Reminder: You must have run `npm install` one time before this will work!)
+*/
+
+/*
+  Write a test that checks the output of formatCourseworkResult when passed the following trainee:
+  {
+    name: "Xin",
+    score: 63
+  }
+*/
+
+/*
+  Write a test that checks the output of formatCourseworkResult when passed the following trainee:
+  {
+    name: "Mona",
+    score: 78
+  }
+*/
+
+/*
+  Write a test that checks the output of formatCourseworkResult when passed the following trainee:
+  {
+    name: "Ali",
+    score: 49,
+    age: 33,
+    subjects: ["JavaScript", "React", "CSS"]
+  }
+*/
+
+/*
+  Write a test that checks the output of formatCourseworkResult when passed the following trainee:
+  {
+    score: 90,
+    age: 29
+  }
+*/
+
+/*
+  Write a test that checks the output of formatCourseworkResult when passed the following trainee:
+  {
+    name: "Aman",
+    subjects: ["HTML", "CSS", "Databases"]
+  }
+*/


### PR DESCRIPTION
Adds some exercises to get trainees to write tests (instead of just using the output of tests).

I've split into a simpler example with a bit more scaffolding, and a more advanced example with a bit more complexity.

I'll leave this as a draft PR for now, as I think we may need to add supporting content to the syllabus around how to write tests. @CodeYourFuture/global-syllabus is due to discuss TDD soon, so this is more of a proposal for discussion.